### PR TITLE
Inner constructor refactor

### DIFF
--- a/examples/basic_horizontal_flow.jl
+++ b/examples/basic_horizontal_flow.jl
@@ -17,7 +17,7 @@ const coarse_ny = 10
 # Model instantiation
 grid = RegRectilinearGrid(-Lx, Lx, -Ly, Ly, Δgrid, Δgrid)
 ocean = Ocean(grid, 0.0, 0.0, 0.0)
-wind = Wind(zeros(grid.dims .+ 1), zeros(grid.dims .+ 1), fill(-20.0, grid.dims .+ 1))
+atmos = Atmos(zeros(grid.dims .+ 1), zeros(grid.dims .+ 1), fill(-20.0, grid.dims .+ 1))
 
 # Domain creation - boundaries and topography
 nboundary = CollisionBoundary(grid, North())
@@ -40,7 +40,7 @@ jldopen("test/test_mc_points.jld2", "r") do f
 end
 floe_arr = StructArray([floe1])
 
-model = Model(grid, ocean, wind, domain, floe_arr)
+model = Model(grid, ocean, atmos, domain, floe_arr)
 
 # Simulation setup
 modulus = 1.5e3*(mean(sqrt.(floe_arr.area)) + minimum(sqrt.(floe_arr.area)))

--- a/src/Subzero.jl
+++ b/src/Subzero.jl
@@ -7,7 +7,7 @@ export
     AbstractGrid,
     RegRectilinearGrid,
     Ocean,
-    Wind,
+    Atmos,
     OpenBC,
     PeriodicBC,
     CollisionBC,

--- a/src/collisions.jl
+++ b/src/collisions.jl
@@ -280,7 +280,7 @@ Inputs:
 Outputs: None. All forces in the x direction set to 0 if the point the force is applied is the northern or southern boundary value.
 """
 function normal_direction_correct!(forces, fpoints, boundary::Union{AbstractBoundary{North, <:AbstractFloat},
-                                                                    AbstractBoundary{South, <:AbstractFloat}}, ::Type{T} = Float64) where T
+AbstractBoundary{South, <:AbstractFloat}}, ::Type{T} = Float64) where T
     forces[fpoints[:, 2] .== boundary.val, 1] .= T(0.0)
     return
 end

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -478,9 +478,9 @@ function floe_OA_forcings!(floe, m, c, Δd, ::Type{T} = Float64) where T
         xknots, xknot_idx = find_interp_knots(mc_cols, m.grid.xg, Δd, m.domain.east, T)
         yknots, yknot_idx = find_interp_knots(mc_rows, m.grid.yg, Δd, m.domain.north, T)
 
-        # Wind Interpolation for Monte Carlo Points
-        uatm_interp = linear_interpolation((yknots, xknots), m.wind.u[yknot_idx, xknot_idx])
-        vatm_interp = linear_interpolation((yknots, xknots), m.wind.v[yknot_idx, xknot_idx])
+        # Atmos Interpolation for Monte Carlo Points
+        uatm_interp = linear_interpolation((yknots, xknots), m.atmos.u[yknot_idx, xknot_idx])
+        vatm_interp = linear_interpolation((yknots, xknots), m.atmos.v[yknot_idx, xknot_idx])
         vals = [uatm_interp(mc_yr[i], mc_xr[i]) for i in eachindex(mc_xr)]
         avg_uatm = mean([uatm_interp(mc_yr[i], mc_xr[i]) for i in eachindex(mc_xr)])
         avg_vatm = mean([vatm_interp(mc_yr[i], mc_xr[i]) for i in eachindex(mc_xr)])

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -152,15 +152,15 @@ Update model's ocean and heat flux from atmosphere effects.
 Input:
         m <Model>
 Outputs: 
-        None. The ocean stress fields are updated from wind stress.
-        Heatflux is also updated with ocean and wind temperatures. 
+        None. The ocean stress fields are updated from atmos stress.
+        Heatflux is also updated with ocean and atmos temperatures. 
 """
 function timestep_atm!(m, c)
-    Δu_AO = m.wind.u .- m.ocean.u
-    Δv_AO = m.wind.v .- m.ocean.v
+    Δu_AO = m.atmos.u .- m.ocean.u
+    Δv_AO = m.atmos.v .- m.ocean.v
     m.ocean.taux .= c.ρa  *c.Cd_ao * sqrt.(Δu_AO.^2 + Δv_OI.^2) .* Δu_AO
     m.ocean.tauy .= c.ρa * c.Cd_ao * sqrt.(Δu_AO.^2 + Δv_OI.^2) .* Δv_AO
-    m.hflx .= c.k/(c.ρi*c.L) .* (wind.temp .- ocean.temp)
+    m.hflx .= c.k/(c.ρi*c.L) .* (atmos.temp .- ocean.temp)
 end
 
 function timestep_sim!(sim, tstep, ::Type{T} = Float64) where T
@@ -220,7 +220,7 @@ function timestep_sim!(sim, tstep, ::Type{T} = Float64) where T
     for idx in remove_idx
         StructArrays.foreachfield(f -> deleteat!(f, idx), m.floes)
     end
-    m.ocean.hflx .= sim.consts.k/(sim.consts.ρi*sim.consts.L) .* (m.wind.temp .- m.ocean.temp)
+    m.ocean.hflx .= sim.consts.k/(sim.consts.ρi*sim.consts.L) .* (m.atmos.temp .- m.ocean.temp)
     # h0 = real(sqrt.(Complex.((-2Δt * newfloe_Δt) .* hflx)))
     # mean(h0)
 

--- a/test/qualitative_behavior.jl
+++ b/test/qualitative_behavior.jl
@@ -26,8 +26,8 @@ Expected Behavior:
 zero_ocn = Ocean(grid, 0.0, 0.0, 0.0)
 meridional_ocn = Ocean(grid, 0.0, 1.0, 0.0)
 
-zero_wind = Wind(grid, 0.0, 0.0, 0.0)
-zonal_wind = Wind(grid, 3.0, 0.0, 0.0)
+zero_atmos = Atmos(grid, 0.0, 0.0, 0.0)
+zonal_atmos = Atmos(grid, 3.0, 0.0, 0.0)
 
 open_domain_no_topo = Subzero.Domain(OpenBoundary(grid, North()),
                                      OpenBoundary(grid, South()),
@@ -62,15 +62,15 @@ sim_arr = Vector{Simulation}(undef, 0)
 Simulation 1: One floe pushed by meridional (south-to-north) 1m/s ocean flow. Floe is initally stationary.
 Expected Behavior: Floe velocity quickly reaches ocean velocity and flows northward. 
 """
-model1 = Model(grid, meridional_ocn, zero_wind, open_domain_no_topo, deepcopy(stationary_rect_floe))
+model1 = Model(grid, meridional_ocn, zero_atmos, open_domain_no_topo, deepcopy(stationary_rect_floe))
 simulation1 = Simulation(name = "sim1", model = model1, consts = standard_consts, Δt = 10, nΔt = nΔt, COLLISION = false)
 push!(sim_arr, simulation1)
 """
-Simulation 2: One floe pushed by zonal (west-to-east) 1m/s wind flow. Ocean-ice drag coefficent set to 0.
+Simulation 2: One floe pushed by zonal (west-to-east) 1m/s atmos flow. Ocean-ice drag coefficent set to 0.
             Floe is initally stationary.
 Expected Behavior: Floe should drift to the right due to Coriolis force in the northern hemisphere. 
 """
-model2 = Model(grid, zero_ocn, zonal_wind, open_domain_no_topo, deepcopy(stationary_rect_floe))
+model2 = Model(grid, zero_ocn, zonal_atmos, open_domain_no_topo, deepcopy(stationary_rect_floe))
 simulation2 = Simulation(name = "sim2", model = model2, consts = no_ocndrag_consts, Δt = 50, nΔt = nΔt, COLLISION = false)
 push!(sim_arr, simulation2)
 
@@ -80,7 +80,7 @@ Another floe woth opposite initial velocity hits the other side of the collision
 free of the ocean.
 Expected Behavior: Floes should bounce off of the topography elements and then off of the walls. 
 """
-model3 = Model(grid, zero_ocn, zero_wind, collision_domain_topo, deepcopy(zonal_2rect_floe))
+model3 = Model(grid, zero_ocn, zero_atmos, collision_domain_topo, deepcopy(zonal_2rect_floe))
 simulation3 = Simulation(name = "sim3", model = model3, consts = no_drag_consts, Δt = 10, nΔt = nΔt, COLLISION = true)
 push!(sim_arr, simulation3)
 


### PR DESCRIPTION
Refactored inner constructors according to [this guide](https://shuvomoy.github.io/blogs/posts/Defining-inner-constructor-with-parametric-types-in-Julia/). 

Changed Wind to Atmos for greater generality. 

Cleaned up and added to topography, boundary, and domain tests. 