### PR TITLE
Fix path error to mp4 files

### DIFF
--- a/docs/literate/examples/forcing_contained_floes.jl
+++ b/docs/literate/examples/forcing_contained_floes.jl
@@ -102,9 +102,9 @@ model = Model(grid, ocean, atmos, domain, floe_arr)
 
 # ## Output Writer Creation
 dir = "forcing_contained_floes"
-init_fn, floe_fn = joinpath(dir, "contained_floes_init_state.jld2"), joinpath(dir, "contained_floes.jld2")
-initwriter = InitialStateOutputWriter(filename = init_fn, overwrite = true)
-floewriter = FloeOutputWriter(50, filename = floe_fn, overwrite = true)
+init_fn, floe_fn = "contained_floes_init_state.jld2", "contained_floes.jld2"
+initwriter = InitialStateOutputWriter(filename = init_fn, dir = dir, overwrite = true)
+floewriter = FloeOutputWriter(50, filename = floe_fn, dir = dir, overwrite = true)
 writers = OutputWriters(initwriter, floewriter)
 
 # ## Simulation Creation
@@ -124,8 +124,7 @@ simulation = Simulation(
 run!(simulation)
 
 # ## Plotting the Simulation
-output_fn = joinpath(dirname(floe_fn), "contained_floes.mp4")
-plot_sim(floe_fn, init_fn, Δt, output_fn);
+plot_sim(joinpath(dir, floe_fn), joinpath(dir, init_fn), Δt, joinpath(dir, "contained_floes.mp4"))
 
 # ```@raw html
 # <video width="auto" controls autoplay loop>

--- a/docs/literate/examples/moving_bounds.jl
+++ b/docs/literate/examples/moving_bounds.jl
@@ -49,16 +49,16 @@ floe_arr = initialize_floe_field(
 )
 nfloes = length(floe_arr)
 floe_arr.u .= 0  # set the inital floe velocities manually
-floe_arr.v .= -0.01
+floe_arr.v .= -0.01;
 
 # ## Model creation
 model = Model(grid, ocean, atmos, domain, floe_arr)
 
 # ## Output Writer Setup
 dir = "moving_bounds"
-init_fn, floe_fn = joinpath(dir, "moving_bounds_init_state.jld2"), joinpath(dir, "moving_bounds.jld2")
-initwriter = InitialStateOutputWriter(filename = init_fn, overwrite = true)
-floewriter = FloeOutputWriter(50, filename = floe_fn, overwrite = true)
+init_fn, floe_fn = "moving_bounds_init_state.jld2", "moving_bounds.jld2"
+initwriter = InitialStateOutputWriter(dir = dir, filename = init_fn, overwrite = true)
+floewriter = FloeOutputWriter(50, dir= dir, filename = floe_fn, overwrite = true)
 writers = OutputWriters(initwriter, floewriter)
 
 # ## Simulation settings 
@@ -93,8 +93,7 @@ simulation = Simulation(
 run!(simulation)
 
 # ## Plotting the Simulation
-output_fn = joinpath(dirname(floe_fn), "moving_bounds.mp4")
-plot_sim(floe_fn, init_fn, Δt, output_fn);
+plot_sim(joinpath(dir, floe_fn), joinpath(dir, init_fn), Δt, joinpath(dir, "moving_bounds.mp4"))
 
 # ```@raw html
 # <video width="auto" controls autoplay loop>

--- a/docs/literate/examples/shear_flow.jl
+++ b/docs/literate/examples/shear_flow.jl
@@ -54,8 +54,8 @@ atmos = Atmos(; u = 0.0, v = 0.0, temp = -1.0, grid)
 # ## Floe Creation
 floe_settings = FloeSettings(subfloe_point_generator = SubGridPointsGenerator(grid, 2))
 floe_arr = initialize_floe_field(
-    50,
     FT,
+    50,
     [0.75],
     domain,
     hmean,
@@ -73,9 +73,9 @@ consts = Constants(E = modulus)
 
 # ## Output Creation
 dir = "shear_flow"
-init_fn, floe_fn = joinpath(dir, "shear_flow_init_state.jld2"), joinpath(dir, "shear_flow_floes.jld2")
-initwriter = InitialStateOutputWriter(filename = init_fn, overwrite = true)
-floewriter = FloeOutputWriter(50, filename = floe_fn, overwrite = true)
+init_fn, floe_fn = "shear_flow_init_state.jld2", "shear_flow_floes.jld2"
+initwriter = InitialStateOutputWriter(dir = dir, filename = init_fn, overwrite = true)
+floewriter = FloeOutputWriter(50, dir = dir, filename = floe_fn, overwrite = true)
 writers = OutputWriters(initwriter, floewriter)
 
 # ## Simulation Creation
@@ -86,8 +86,7 @@ simulation = Simulation(; model, consts, writers, Δt, nΔt, floe_settings,
 run!(simulation)
 
 # ## Plotting the Simulation
-output_fn = joinpath(dirname(floe_fn), "shear_flow.mp4")
-plot_sim(floe_fn, init_fn, Δt, output_fn)
+plot_sim(joinpath(dir, floe_fn), joinpath(dir, init_fn), Δt, joinpath(dir, "shear_flow.mp4"))
 
 # ```@raw html
 # <video width="auto" controls autoplay loop>

--- a/docs/literate/examples/simple_strait.jl
+++ b/docs/literate/examples/simple_strait.jl
@@ -92,9 +92,9 @@ ridgeraft_settings = RidgeRaftSettings(
 
 # ## Output Creation
 dir = "simple_strait"
-init_fn, floe_fn = joinpath(dir, "simple_strait_init_state.jld2"), joinpath(dir, "simple_strait_floes.jld2")
-initwriter = InitialStateOutputWriter(filename = init_fn, overwrite = true)
-floewriter = FloeOutputWriter(50, filename = floe_fn, overwrite = true)
+init_fn, floe_fn = "simple_strait_init_state.jld2", "simple_strait_floes.jld2"
+initwriter = InitialStateOutputWriter(dir = dir, filename = init_fn, overwrite = true)
+floewriter = FloeOutputWriter(50, dir = dir, filename = floe_fn, overwrite = true)
 writers = OutputWriters(initwriter, floewriter)
 
 # ## Simulation Creation
@@ -107,8 +107,7 @@ simulation = Simulation(; model, consts, writers, Δt, nΔt,
 run!(simulation)
 
 # ## Plotting the Simulation
-output_fn = joinpath(dirname(floe_fn), "simple_strait.mp4")
-plot_sim(floe_fn, init_fn, Δt, output_fn)
+plot_sim(joinpath(dir, floe_fn), joinpath(dir, init_fn), Δt, joinpath(dir, "simple_strait.mp4"))
 
 # ```@raw html
 # <video width="auto" controls autoplay loop>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,8 +4,6 @@ import GeoInterface as GI
 import GeometryOps as GO
 import LibGEOS as LG
 
-println(pwd())
-
 function jl_to_md(input, output)
     # turns .jl files in input to .md files in output
     for ipath in readdir(input, join = true)
@@ -64,7 +62,6 @@ makedocs(;
         ],
     ],
     warnonly = true,
-    clean = false,  # TODO: remove before pushing to production
 )
 
 deploydocs(;


### PR DESCRIPTION
In the last commit, I updated the documentation website with videos. Somehow, the path to the mp4 video outputs was wrong. 