### PR TITLE
JOSS paper edits

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -1,47 +1,322 @@
-@article{Bezanson,
-  title={Julia: A fresh approach to numerical computing},
-  author={Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B},
-  journal={SIAM review},
-  volume={59},
-  number={1},
-  pages={65--98},
-  year={2017},
-  publisher={SIAM}
+@article{bezanson2017,
+  title = {Julia: {{A Fresh Approach}} to {{Numerical Computing}}},
+  shorttitle = {Julia},
+  author = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
+  year = 2017,
+  month = jan,
+  journal = {SIAM Rev.},
+  volume = {59},
+  number = {1},
+  pages = {65--98},
+  publisher = {{Society for Industrial and Applied Mathematics}},
+  issn = {0036-1445},
+  doi = {10.1137/141000671},
+  urldate = {2025-05-20},
+  abstract = {This is the third in a series of papers on aspects of modern computing environments that are relevant to statistical data analysis. In this paper, we discuss programming environments. In particular, we argue that integrated programming environments (for example, Lisp and Smalltalk environments) are more appropriate as a base for data analysis than conventional operating systems (for example, Unix).},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/bezanson2017.pdf}
 }
+% == BibTeX quality report for bezanson2017:
+% ? Possibly abbreviated journal title SIAM Rev.
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused Library catalog ("epubs.siam.org (Atypon)")
+% ? unused Publication title ("SIAM Review")
+% ? unused Url ("https://epubs.siam.org/doi/10.1137/141000671")
 
-@article{Manucharyan,
-  title={SubZero: A sea ice model with an explicit representation of the floe life cycle},
-  author={Manucharyan, Georgy E and Montemuro, Brandon P},
-  journal={Journal of Advances in Modeling Earth Systems},
-  volume={14},
-  number={12},
-  pages={e2022MS003247},
-  year={2022},
-  publisher={Wiley Online Library}
+@article{brenner2023c,
+  title = {Scale-{{Dependent Air-Sea Exchange}} in the {{Polar Oceans}}: {{Floe-Floe}} and {{Floe-Flow Coupling}} in the {{Generation}} of {{Ice-Ocean Boundary Layer Turbulence}}},
+  shorttitle = {Scale-{{Dependent Air-Sea Exchange}} in the {{Polar Oceans}}},
+  author = {Brenner, Samuel and Horvat, Christopher and Hall, Paul and Lo Piccolo, Anna and {Fox-Kemper}, Baylor and Labb{\'e}, St{\'e}phane and Dansereau, V{\'e}ronique},
+  year = 2023,
+  journal = {Geophysical Research Letters},
+  volume = {50},
+  number = {23},
+  pages = {e2023GL105703},
+  issn = {1944-8007},
+  doi = {10.1029/2023GL105703},
+  urldate = {2023-12-08},
+  abstract = {Sea ice is a heterogeneous, evolving mosaic of individual floes, varying in spatial scales from meters to tens of kilometers. Both the internal dynamics of the floe mosaic (floe-floe interactions), and the evolution of floes under ocean and atmospheric forcing (floe-flow interactions), determine the exchange of heat, momentum, and tracers between the lower atmosphere and upper ocean. Climate models do not represent either of these highly variable interactions. We use a novel, high-resolution, discrete element modeling framework to examine ice-ocean boundary layer (IOBL) turbulence within a domain approximately the size of a climate model grid. We show floe-scale effects could cause a marked increase in the production of fine-scale three-dimensional turbulence in the IOBL relative to continuum model approaches, and provide a method of representing that turbulence using bulk parameters related to the spatial variance of the ice and ocean: the floe size distribution and the ocean kinetic energy spectrum.},
+  copyright = {\copyright{} 2023 The Authors.},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/brenner2023c.pdf}
 }
+% == BibTeX quality report for brenner2023c:
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused extra: _eprint ("https://onlinelibrary.wiley.com/doi/pdf/10.1029/2023GL105703")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2023GL105703")
 
-@article{Montemuro,
-    doi = {10.21105/joss.05039},
-    url = {https://doi.org/10.21105/joss.05039},
-    year = {2023},
-    publisher = {The Open Journal},
-    volume = {8},
-    number = {88},
-    pages = {5039},
-    author = {Brandon P. Montemuro and Georgy E. Manucharyan},
-    title = {SubZero: a discrete element sea ice model that simulates floes as evolving concave polygons},
-    journal = {Journal of Open Source Software}
+@misc{brenner2025,
+  title = {Patterns of Sea Ice Floes Shape Ocean Turbulence in the Marginal Ice Zone},
+  author = {Brenner, Samuel and Thompson, Andrew and Gupta, Mukund},
+  year = 2025,
+  month = nov,
+  publisher = {Research Square},
+  issn = {2693-5015},
+  doi = {10.21203/rs.3.rs-8099873/v1},
+  urldate = {2026-01-04},
+  abstract = {As Arctic sea ice transitions to a more seasonal regime, the marginal ice zone (MIZ) is emerging as increasingly relevant to the climate system. Within this region, the evolution of turbulent ocean eddies is tightly coupled to the fate of sea ice. Yet, most existing approaches treat sea ice as a continuum, even though in the MIZ it is composed of discrete floes whose sizes overlap those of the eddies. Here, using a coupled model system that explicitly resolves interactions between individual floes and the ocean, we show that the patterns of sea ice cover regulate the energy pathways associated with large-scale turbulence. Variations in the floe size distribution reshape both the generation and damping of ocean eddies, producing more than a twofold difference in kinetic energy between realizations with different floe arrangements. These differences arise as both the sizes and spatial organization of floes imprint on surface forcing, while the resulting turbulence reorganizes the ice into clusters and open-water regions at scales distinct from the floes themselves. Heterogeneity in the sea ice cover, not just its concentration, govern upper-ocean turbulence, underscoring the challenges inherent to the growing implementation of high-resolution Earth-system models.},
+  archiveprefix = {Research Square},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/brenner2025.pdf;/Users/sdbrenner/Zotero/storage/EDNPMX5N/brenner2025.pdf}
 }
+% == BibTeX quality report for brenner2025:
+% ? unused Url ("https://www.researchsquare.com/article/rs-8099873/v1")
 
-@article{Ramadhan,
-    doi = {10.21105/joss.02018},
-    url = {https://doi.org/10.21105/joss.02018},
-    year = {2020},
-    publisher = {The Open Journal},
-    volume = {5},
-    number = {53},
-    pages = {2018},
-    author = {Ali Ramadhan and Gregory LeClaire Wagner and Chris Hill and Jean-Michel Campin and Valentin Churavy and Tim Besard and Andre Souza and Alan Edelman and Raffaele Ferrari and John Marshall},
-    title = {Oceananigans.jl: Fast and friendly geophysical fluid dynamics on GPUs},
-    journal = {Journal of Open Source Software}
+@article{damsgaard2018,
+  title = {Application of {{Discrete Element Methods}} to {{Approximate Sea Ice Dynamics}}},
+  author = {Damsgaard, A. and Adcroft, A. and Sergienko, O.},
+  year = 2018,
+  journal = {Journal of Advances in Modeling Earth Systems},
+  volume = {10},
+  number = {9},
+  pages = {2228--2244},
+  issn = {1942-2466},
+  doi = {10.1029/2018MS001299},
+  urldate = {2025-12-24},
+  abstract = {Lagrangian models of sea ice dynamics have several advantages over Eulerian continuum models. Spatial discretization on the ice floe scale is natural for Lagrangian models and offers exact solutions for mechanical nonlinearities with arbitrary sea ice concentrations. This allows for improved model performance in ice-marginal zones, where sea ice is fragmented. Furthermore, Lagrangian models can explicitly simulate jamming processes that occur when sea ice moves through narrow confinements. While difficult to parameterize in continuum formulations, jamming emerges spontaneously in dense granular systems simulated in a Lagrangian framework. Here we present a flexible discrete element framework for approximating Lagrangian sea ice mechanics at the ice floe scale, forced by ocean and atmosphere velocity fields. Our goal is to evaluate the potential of models simpler than the traditional discrete element methods for granular dynamics. We demonstrate that frictionless contact models based on compressive stiffness alone are unlikely to produce jamming and describe two different approaches based on Coulomb friction and cohesion which both result in increased bulk shear strength of the granular assemblage. The frictionless but cohesive contact model displays jamming behavior which is similar to the more complex model with Coulomb friction and ice floe rotation at larger scales and has significantly lower computational cost.},
+  copyright = {\copyright 2018. The Authors.},
+  langid = {english},
+  keywords = {discrete element method,granular material,jamming,Lagrangian model,rheology,sea ice},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/damsgaard2018.pdf}
 }
+% == BibTeX quality report for damsgaard2018:
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused extra: _eprint ("https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2018MS001299")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2018MS001299")
+
+@article{gupta2022,
+  title = {Regimes of Sea-Ice Floe Melt: {{Ice-ocean}} Coupling at the Submesoscales},
+  shorttitle = {Regimes of Sea-Ice Floe Melt},
+  author = {Gupta, Mukund and Thompson, Andrew F.},
+  year = 2022,
+  journal = {JGR Oceans},
+  volume = {n/a},
+  number = {n/a},
+  pages = {e2022JC018894},
+  issn = {2169-9291},
+  doi = {10.1029/2022JC018894},
+  urldate = {2022-08-18},
+  abstract = {Marginal ice zones are composed of discrete sea-ice floes, whose dynamics are not well captured by the continuum representation of sea ice in most climate models. This study makes use of an ocean Large Eddy Simulation (LES) model, coupled to cylindrical sea-ice floes, to investigate thermal and mechanical interactions between melt-induced submesoscale features and sea-ice floes, during summer conditions. We explore the sensitivity of sea-ice melt rates and upper-ocean turbulence properties to floe size, ice-ocean drag and surface winds. Under low wind conditions, upper ocean turbulence transports warm cyclonic filaments from the open ocean toward the center of the floes and enhance their basal melt. This heat transport is partially suppressed by trapping of ice within cold anticyclonic features. When winds are stronger, melt rates are enhanced by the decoupling of floes from the cold, melt-induced lens underneath sea ice. Distinct dynamical regimes emerge in which the influence of warm filaments on sea-ice melt is mitigated by the strength of ice-ocean coupling and eddy size relative to floe size. Simple scaling laws, which may help parameterize these processes in coarse continuum-based sea-ice models, successfully capture floe melt rates under these limiting regimes.},
+  langid = {english},
+  keywords = {arctic,floe,melt,sea ice,submesoscale},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/gupta2022.pdf}
+}
+% == BibTeX quality report for gupta2022:
+% ? unused extra: _eprint ("https://onlinelibrary.wiley.com/doi/pdf/10.1029/2022JC018894")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Publication title ("Journal of Geophysical Research: Oceans")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2022JC018894")
+
+@article{gupta2024,
+  title = {Eddy-{{Induced Dispersion}} of {{Sea Ice Floes}} at the {{Marginal Ice Zone}}},
+  author = {Gupta, Mukund and G{\"u}rcan, Emma and Thompson, Andrew F.},
+  year = 2024,
+  journal = {GRL},
+  volume = {51},
+  number = {2},
+  pages = {e2023GL105656},
+  issn = {1944-8007},
+  doi = {10.1029/2023GL105656},
+  urldate = {2024-01-17},
+  abstract = {Ocean heat exchanges at the marginal ice zone (MIZ) play an important role in melting sea ice. Mixed-layer eddies transport heat and ice floes across the MIZ, facilitating the pack's access to warm waters. This study explores these frontal dynamics using disk-shaped floes coupled to an upper-ocean model simulating the sea ice edge. Numerical experiments reveal that small floes respond more strongly to fine-scale ocean currents, which favors higher dispersion rates and weakens sea ice drag onto the underlying ocean. Floes with radii smaller than resolved turbulent filaments ({$\sim$}2--4 km) result in a wider and more energetic MIZ, by a factor of 70\% each, compared to larger floes. We hypothesize that this floe size dependency may affect sea ice break-up by controlling oceanic energy propagation into the MIZ and modulate the sea ice pack's melt rate by regulating lateral heat transport toward the sea ice cover.},
+  copyright = {\copyright{} 2024. The Authors.},
+  langid = {english},
+  keywords = {eddies,heat transport,oceanography,polar climate,sea ice,submesoscale},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/gupta2024.pdf}
+}
+% == BibTeX quality report for gupta2024:
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused extra: _eprint ("https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2023GL105656")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Publication title ("Geophysical Research Letters")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2023GL105656")
+
+@article{herman2013,
+  title = {Numerical Modeling of Force and Contact Networks in Fragmented Sea Ice},
+  author = {Herman, Agnieszka},
+  year = {2013/ed},
+  journal = {Annals of Glaciology},
+  volume = {54},
+  number = {62},
+  pages = {114--120},
+  publisher = {Cambridge University Press},
+  issn = {0260-3055, 1727-5644},
+  doi = {10.3189/2013AoG62A055},
+  urldate = {2022-11-18},
+  abstract = {In this paper, a molecular-dynamics sea-ice model is used to study contact and force networks in fragmented sea ice, composed of separate floes with power-law size distribution. The momentum equations for individual floes, taking into account floe/floe collisions (with Hertzian contact mechanics), are formulated in a way suitable for a computationally efficient numerical algorithm, allowing simulation of systems of thousands of floes. The simulations are performed for a number of scenarios: pure convergence without wind, through a jamming phase transition; constant wind at a constant ice concentration; and an idealized marginal ice zone. An analysis of the statistical properties of the contact and force networks reveals a highly localized, intermittent character of internal stress in the ice, as well as the role of the size-dependent response of floes to the forcing in formation of spatial patterns of internal stress at lower ice concentrations. The results provide a valuable starting point for formulating improved rheology models for fragmented sea ice.},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/herman2013.pdf}
+}
+% == BibTeX quality report for herman2013:
+% ? unused Url ("https://www.cambridge.org/core/journals/annals-of-glaciology/article/numerical-modeling-of-force-and-contact-networks-in-fragmented-sea-ice/57BB7092464F33D012486ACDC03E47B2")
+
+@article{hopkins2004a,
+  title = {A Discrete Element {{Lagrangian}} Sea Ice Model},
+  author = {Hopkins, Mark A.},
+  year = 2004,
+  month = jan,
+  journal = {Engineering Computations},
+  volume = {21},
+  number = {2/3/4},
+  pages = {409--421},
+  publisher = {Emerald Group Publishing Limited},
+  issn = {0264-4401},
+  doi = {10.1108/02644400410519857},
+  urldate = {2024-05-28},
+  abstract = {The ice pack covering the Arctic basin is composed of a multitude of ice parcels of different areas, ages, thicknesses, and deformation histories that are frozen together into larger plates that combine and break apart in response to the demands of ever changing boundary conditions and forcing. Current Arctic sea ice models are Eulerian continuum models that use a plastic yield surface to characterize the constitutive behavior of the pack. An alternative is to adopt a discontinuous Lagrangian approach, based on a discrete element model and explicitly simulate individual ice parcels and the interactions between them. The mechanics of the Lagrangian sea ice model are outlined in detail along with the methods that will be used for validation.},
+  keywords = {Geographic regions,Ice cover,Modelling},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/hopkins2004a.pdf}
+}
+% == BibTeX quality report for hopkins2004a:
+% ? unused Library catalog ("Emerald Insight")
+% ? unused Url ("https://doi.org/10.1108/02644400410519857")
+
+@article{horvat2018,
+  title = {Understanding {{Melting}} Due to {{Ocean Eddy Heat Fluxes}} at the {{Edge}} of {{Sea-Ice Floes}}},
+  author = {Horvat, Christopher and Tziperman, Eli},
+  year = 2018,
+  journal = {Geophys. Res. Lett.},
+  volume = {45},
+  number = {18},
+  pages = {9721--9730},
+  issn = {1944-8007},
+  doi = {10.1029/2018GL079363},
+  urldate = {2021-11-09},
+  abstract = {Understanding how upper-ocean heat content evolves and affects sea ice in the polar regions is necessary to predict past, present, and future weather and climate. Sea ice, a composite of individual floes, varies significantly on scales as small as meters. Lateral gradients in surface forcing across sea-ice concentration gradients can energize subgrid-scale ocean eddies that mix heat in the surface layer and control sea-ice melting. Here the development of baroclinic instability near floe edges is investigated using a high-resolution ocean circulation model, an idealization of a single grid cell of a climate model partially covered in thin, nearly static sea ice. From the resulting ocean circulation we characterize the strength of eddy-induced lateral mixing and heat transport, and the effects on sea-ice melting, as a function of state variables resolved in global climate models.},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/horvat2018.pdf}
+}
+% == BibTeX quality report for horvat2018:
+% ? Possibly abbreviated journal title Geophys. Res. Lett.
+% ? unused extra: _eprint ("https://onlinelibrary.wiley.com/doi/pdf/10.1029/2018GL079363")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Publication title ("Geophysical Research Letters")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2018GL079363")
+
+@article{manucharyan2022b,
+  title = {{{SubZero}}: {{A Sea Ice Model With}} an {{Explicit Representation}} of the {{Floe Life Cycle}}},
+  shorttitle = {{{SubZero}}},
+  author = {Manucharyan, Georgy E. and Montemuro, Brandon P.},
+  year = 2022,
+  journal = {Journal of Advances in Modeling Earth Systems},
+  volume = {14},
+  number = {12},
+  pages = {e2022MS003247},
+  issn = {1942-2466},
+  doi = {10.1029/2022MS003247},
+  urldate = {2023-09-26},
+  abstract = {Sea ice dynamics exhibit granular behavior as individual floes and fracture networks become particularly evident at length scales O(10--100) km and smaller. However, climate models do not resolve floes and represent sea ice as a continuum, while existing floe-scale sea ice models tend to oversimplify floes using discrete elements of predefined simple shapes. The idealized nature of climate and discrete element sea ice models presents a challenge of comparing the model output with floe-scale sea ice observations. Here we present SubZero, a conceptually new sea ice model geared to explicitly simulate the life cycles of individual floes by using complex discrete elements with time-evolving shapes. This unique model uses parameterizations of floe-scale processes, such as collisions, fractures, ridging, and welding, to simulate a wide range of evolving floe shapes and sizes. We demonstrate the novel capabilities of the SubZero model in idealized experiments, including uniaxial compression, the summer-time sea ice flow through the Nares Strait, and winter-time sea ice growth. The model naturally reproduces the statistical behavior of the observed sea ice, such as the power-law appearance of the floe size distribution and the long-tailed ice thickness distribution. The SubZero model could provide a valuable alternative to existing discrete element and continuous sea ice models for simulations of floe interactions.},
+  copyright = {\copyright{} 2022 The Authors. Journal of Advances in Modeling Earth Systems published by Wiley Periodicals LLC on behalf of American Geophysical Union.},
+  langid = {english},
+  keywords = {discrete element method,floe size distribution,floes,granular,ice thickness distribution,sea ice model},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/manucharyan2022b.pdf}
+}
+% == BibTeX quality report for manucharyan2022b:
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused extra: _eprint ("https://onlinelibrary.wiley.com/doi/pdf/10.1029/2022MS003247")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1029/2022MS003247")
+
+@article{montemuro2023,
+  title = {{{SubZero}}: A Discrete Element Sea Ice Model That Simulates Floes as Evolving Concave Polygons},
+  shorttitle = {{{SubZero}}},
+  author = {Montemuro, Brandon P. and Manucharyan, Georgy E.},
+  year = 2023,
+  month = aug,
+  journal = {Journal of Open Source Software},
+  volume = {8},
+  number = {88},
+  pages = {5039},
+  issn = {2475-9066},
+  doi = {10.21105/joss.05039},
+  urldate = {2024-10-03},
+  abstract = {Montemuro et al., (2023). SubZero: a discrete element sea ice model that simulates floes as evolving concave polygons. Journal of Open Source Software, 8(88), 5039, https://doi.org/10.21105/joss.05039},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/montemuro2023.pdf}
+}
+% == BibTeX quality report for montemuro2023:
+% ? unused Library catalog ("joss.theoj.org")
+% ? unused Url ("https://joss.theoj.org/papers/10.21105/joss.05039")
+
+@article{montemuro2024,
+  title = {The {{Role}} of {{Islands}} in {{Sea Ice Transport Through Nares Strait}}},
+  author = {Montemuro, Brandon and Manucharyan, Georgy},
+  year = 2024,
+  month = sep,
+  publisher = {EarthArXiv},
+  urldate = {2024-11-22},
+  abstract = {Nares Strait is a major pathway from the Arctic Ocean and an important climate system component. Sea ice's granular nature is pertinent in such straits with small islands where floes propagate by fracturing upon collisions. Since climate models are relatively coarse and use continuous sea ice rheology, they only partially capture the complexities of floe interactions. We use a floe-scale model, SubZero, to explore the role of islands in sea ice transport through Nares Strait. We demonstrate that SubZero can reproduce the crucial observed sea ice characteristics, including the area transport and variance in area fluxes. We found that a size-dependent critical stress criterion was necessary to simulate the power-law exponent in this domain's floe size distribution. Conducting simulations with and without the islands, we demonstrate the effectiveness of floe-scale models in simulating sea ice dynamics in straits and emphasize small islands' crucial role in affecting overall transport.},
+  copyright = {CC BY Attribution 4.0 International},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/montemuro2024.pdf}
+}
+% == BibTeX quality report for montemuro2024:
+% Missing required field 'journal'
+% ? Title looks like it was stored in title-case in Zotero
+% ? unused Library catalog ("eartharxiv.org")
+% ? unused Url ("https://eartharxiv.org/repository/view/7715/")
+
+@article{rabatel2015a,
+  title = {Dynamics of an Assembly of Rigid Ice Floes},
+  author = {Rabatel, Matthias and Labb{\'e}, St{\'e}phane and Weiss, J{\'e}r{\^o}me},
+  year = 2015,
+  journal = {Journal of Geophysical Research: Oceans},
+  volume = {120},
+  number = {9},
+  pages = {5887--5909},
+  issn = {2169-9291},
+  doi = {10.1002/2015JC010909},
+  urldate = {2022-05-10},
+  abstract = {In this paper, we present a model describing the dynamics of a population of ice floes with arbitrary shapes and sizes, which are exposed to atmospheric and oceanic skin drag. The granular model presented is based on simplified momentum equations for ice floe motion between collisions and on the resolution of linear complementarity problems to deal with ice floe collisions. Between collisions, the motion of an individual ice floe satisfies the linear and angular momentum conservation equations, with classical formula applied to account for atmospheric and oceanic skin drag. To deal with collisions, before they lead to interpenetration, we included a linear complementarity problem based on the Signorini condition and Coulombs law. The nature of the contact is described through a constant coefficient of friction {$\mu$}, as well as a coefficient of restitution describing the loss of kinetic energy during the collision. In the present version of our model, this coefficient is fixed. The model was validated using data obtained from the motion of interacting artificial wood floes in a test basin. The results of simulations comprising few hundreds of ice floes of various shapes and sizes, exposed to different forcing scenarios, and under different configurations, are also discussed. They show that the progressive clustering of ice floes as the result of kinetic energy dissipation during collisions is well captured, and suggest a collisional regimes of floe dispersion at small scales, different from a large-scale regime essentially driven by wind forcing.},
+  langid = {english},
+  keywords = {ice floe motion,ice floes interactions,marginal ice zone,multirigid body,sea ice mechanics},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/rabatel2015a.pdf}
+}
+% == BibTeX quality report for rabatel2015a:
+% ? unused extra: _eprint ("https://onlinelibrary.wiley.com/doi/pdf/10.1002/2015JC010909")
+% ? unused Library catalog ("Wiley Online Library")
+% ? unused Url ("https://onlinelibrary.wiley.com/doi/abs/10.1002/2015JC010909")
+
+@article{ramadhan2020,
+  title = {Oceananigans.Jl: {{Fast}} and Friendly Geophysical Fluid Dynamics on {{GPUs}}},
+  shorttitle = {Oceananigans.Jl},
+  author = {Ramadhan, Ali and Wagner, Gregory LeClaire and Hill, Chris and Campin, Jean-Michel and Churavy, Valentin and Besard, Tim and Souza, Andre and Edelman, Alan and Ferrari, Raffaele and Marshall, John},
+  year = 2020,
+  month = sep,
+  journal = {Journal of Open Source Software},
+  volume = {5},
+  number = {53},
+  pages = {2018},
+  issn = {2475-9066},
+  doi = {10.21105/joss.02018},
+  urldate = {2024-10-04},
+  abstract = {Ramadhan et al., (2020). Oceananigans.jl: Fast and friendly geophysical fluid dynamics on GPUs. Journal of Open Source Software, 5(53), 2018, https://doi.org/10.21105/joss.02018},
+  langid = {english},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/ramadhan2020.pdf}
+}
+% == BibTeX quality report for ramadhan2020:
+% ? unused Library catalog ("joss.theoj.org")
+% ? unused Url ("https://joss.theoj.org/papers/10.21105/joss.02018")
+
+@misc{wagner2025,
+  title = {High-Level, High-Resolution Ocean Modeling at All Scales with {{Oceananigans}}},
+  author = {Wagner, Gregory L. and Silvestri, Simone and Constantinou, Navid C. and Ramadhan, Ali and Campin, Jean-Michel and Hill, Chris and Chor, Tomas and {Strong-Wright}, Jago and Lee, Xin Kai and Poulin, Francis and Souza, Andre and Burns, Keaton J. and Marshall, John and Ferrari, Raffaele},
+  year = 2025,
+  month = feb,
+  number = {arXiv:2502.14148},
+  eprint = {2502.14148},
+  primaryclass = {physics},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2502.14148},
+  urldate = {2025-02-24},
+  abstract = {We describe the vision, user interface, governing equations, and numerical methods that underpin new ocean modeling software called ``Oceananigans''. Oceananigans is being developed by the Climate Modeling Alliance as part of a larger project to build a trainable climate model with quantifiable uncertainty. We argue that Oceananigans status as a popular, capable modeling system realizes a vision for accelerating progress in Earth system modeling that balances demands for model accuracy and performance, needed for state-of-the-art science, against accessibility, which is needed to accelerate development. This vision combines three cooperative elements: (i) a relatively simple finite volume algorithm (ii) optimized for high-resolution simulations on GPUs which is (iii) exposed behind an expressive, high-level user interface (using the Julia programming language in our case). We offer evidence for the vision's potential by illustrating the creative potential of our user interface, showcasing Oceananigans physics with example simulations that range from simple classroom problems to a realistic global ocean simulation spanning all scales of oceanic fluid motion, and describing advances in parameterization, numerical methods, and computational efficiency.},
+  archiveprefix = {arXiv},
+  keywords = {Physics - Atmospheric and Oceanic Physics,Physics - Computational Physics,Physics - Fluid Dynamics},
+  file = {/Users/sdbrenner/Documents/Brenner_Postdoc_Caltech/Zotero_References/wagner2025.pdf;/Users/sdbrenner/Zotero/storage/LC4QBDSP/wagner2025.pdf}
+}
+% == BibTeX quality report for wagner2025:
+% ? unused Url ("http://arxiv.org/abs/2502.14148")
+
+
+% The following packages could be loaded to get more precise latex output:
+% * textcomp

--- a/paper.md
+++ b/paper.md
@@ -68,3 +68,11 @@ An example coupled simulation is demonstrated in \autoref{fig:oceananigans_coupl
 \label{fig:oceananigans_coupled_example}](oceananigans_coupled_example.png)
 
 Finally, Subzero.jl is continuously tested against a suite of unit tests and integration tests that compare its behavior to the original MATLAB model, and confirm that the model conserves both energy and momentum.
+
+# Acknowledgements
+
+Our work is supported by the Office of Naval Research (ONR) grant
+N00014-19-1-2421. The authors thank the authors of Subzero, Georgy Manucharyan
+and Brandon Montemuro for their guidance and advice during the porting process.
+
+# References

--- a/paper.md
+++ b/paper.md
@@ -14,7 +14,7 @@ authors:
     orcid: 0000-0000-0000-0000
     affiliation: 3
   - name: Samuel Brenner
-    orcid: 0000-0000-0000-0000
+    orcid: 0000-0002-0826-1294
     affiliation: 1
   - name: Andrew Thompson
     orcid: 0000-0000-0000-0000
@@ -30,62 +30,41 @@ date: 1 January 2026
 bibliography: paper.bib
 ---
 
-# Statement of need
-Arctic sea ice extent and concentration continue to decline at rates that are
-commonly underestimated by climate projection models. Potential sources of
-uncertainty arise from an inaccurate representation of interactions between the
-ocean and sea ice within these climate models, as well as the simplification of
-sea-ice dynamics for the sake of reducing computational complexity.
-Discrete-element models (DEMs), where each piece of sea ice is represented as an
-individual simulation element, all of which can dynamically interact, are used
-to explore these uncertainties and study fine-scale sea ice dynamics. However,
-these models are computationally expensive and are not commonly coupled to a
-dynamic ocean to explore two-way feedbacks. We present Subzero.jl, a native Julia [@Bezanson:2017]
-version of MATLAB discrete-element model SubZero [@Montemuro:2023] that addresses both of these two
-problems. 
-
 # Summary
-SubZero [@Montemuro:2023], a novel DEM written in MATLAB, pushes beyond
-traditional models by representing sea ice floes as polygonal elements that
-change in shape, mass, and number over time as a result of interactions with
-other floes and topographical elements. These features address the uncertainty
-of simplified sea ice dynamics within continuous models mentioned above, but are
-computationally expensive. To increase the scale and speed of simulations, it
-was determined that SubZero should be ported from MATLAB to the Julia
-programming language [@Bezanson:2017] and re-engineered to improve both
-performance and usability. Additionally, exploration of sea ice and ocean
-dynamics, the second source of uncertiantly discussed above, requires coupling
-with a dynamic ocean model. Porting SubZero to Julia and adding two-way coupling
-infrastructure allows coupling with Oceananigans.jl [@Ramadhan:2020], allowing
-exploration of new scientific questions.
+Subzero.jl is a discrete-element model (DEM) for simulating sea-ice floe dynamics, designed to be fast, flexible, and user-friendly.
+The model is a port of the MATLAB-based SubZero [@Montemuro2023] to the Julia programming language [@Bezanson:2017], with substantial re-engineering to increase speed, to improve extensibility and usability, and to provide native infrastructure for explicit coupling with external ocean dynamics models.
+The model is available as a registered Julia package.
 
-First of all, the switch to Julia allows a more extendable, user-friendly interface.
-With a modular simulation and model object, Subzero.jl allows users to craft detailed
-simulations with a script-based interface without ever interacting with the source code.
-Users can easily turn on and off various physical processes like fracturing, ridging, and welding.
-It is also easy for the user to extend existing functionality, such as the creating new domain boundary types and floe fracture criteria, within their own scripts, rather than within the source code, using Julia's multiple dispatch paradigm. This flexibility is highlighted in the tutorial and examples
-provided with the documentation.
+# Statement of need
+Arctic sea ice extent and concentration continue to decline at rates that are commonly underestimated by climate projection models [@cite].
+Potential sources of uncertainty arise from an inaccurate representation of interactions between the ocean and sea ice within these climate models, as well as the simplification of sea-ice dynamics for the sake of reducing computational complexity.
+Discrete-element models (DEMs), where each piece of sea ice is represented as an individual simulation element, all of which can dynamically interact, are used to explore these uncertainties and study fine-scale sea ice dynamics. 
+While a range of sea ice DEMs are available [e.g., @Hopkins2004,@Herman2013,@Rabatel2015,@Damsgaard2018, and others], many of these models make a range of simplifications, particularly in the geometric representation of the floes.
+The MATLAB-based SubZero model [@Montemuro2023] allows for complex, and evolving, floe shapes but is computationally expensive. 
+Moreover, due to the highly connected nature of sea ice floes and ocean processes [@Horvat2018,@Gupta2022,@Gupta2024,@Brenner2023c], there is a need for DEM simulations to be coupled to a dynamic ocean model to explore two-way feedbacks--a feature not readily available for most extant models. 
+We present Subzero.jl, a native Julia [@Bezanson2017] version of the MATLAB discrete-element model SubZero [@Montemuro2023, @Manucharyan2022] that addresses both of these two problems. 
 
-Subzero.jl also achieves speeds up to [ADD DETAILS] times faster than the original model when running the repository example scripts. This speed up will enable longer runs, allowing ...
+# Functionality
+Subzero.jl, represents sea ice floes as polygonal elements that can change in shape, mass, and number over time as a result of interactions with other floes and topographical elements, and move in response to forcing from either the atmosphere or the ocean [@Manucharyan2022].
 
-Furthermore, the new coupling framework allows...
+This new Julia implementation allows a more extendable, user-friendly interface relative to the previous MATLAB version.
+With a modular simulation and model object, Subzero.jl allows users to craft detailed simulations with a script-based interface without ever interacting with the source code.
+Users can easily turn on and off various physical processes, such as fracturing, ridging, and welding.
+It is also easy for the user to extend existing functionality, such as creating new domain boundary types and floe fracture criteria, within their own scripts, rather than within the source code, using Julia's multiple dispatch paradigm. 
+This flexibility is highlighted in the tutorial and examples provided with the documentation.
 
-Finally, Subzero.jl is continuously tested against a suite of unit tests and integration
-tests that compare its behavior to the original MATLAB model, and confirm that
-the model conserves both energy and momentum. 
+Subzero.jl also achieves speeds up to [ADD DETAILS] times faster than the original model when running the repository example scripts (see \autoref{fig:speed_comparison}). 
+This speed up will enable longer and more complex simulations, allowing ...
 
+![Caption for example figure.\label{fig:speed_comparison}](speed_comparison.png)
 
-<!-- Figures can be included like this:
-![Caption for example figure.\label{fig:example}](figure.png)
-and referenced from text using \autoref{fig:example}.
+Furthermore, the new coupling framework enables two-way coupled simulations with the large-eddy simulation (LES) ocean model Oceananigans.jl [@Ramadhan2020,@Wagner2025], enabling exploration of new scientific questions.
+In this configuration, sea-ice floes in Subzero.jl are forced by gridded ocean velocity fields supplied by Oceananigans.jl, while floe-resolved ice-ocean stresses computed by Subzero.jl are re-gridded and returned to the ocean model as a spatially heterogeneous surface boundary condition.
+The exchange of fields is implemented using callback functionality in Oceananigans.jl, allowing serial coupling at user-defined frequencies.
+This coupled DEM-LES system resolves the mechanical interaction between evolving ocean fields and individual sea ice floes, enabling investigation of floe-scale modulation of upper-ocean dynamics [e.g., @Brenner2025].
+An example coupled simulation is demonstrated in \autoref{fig:oceananigans_coupled_example}.
 
-Figure sizes can be customized by adding an optional second parameter:
-![Caption for example figure.](figure.png){ width=20% } -->
+![Example Subzero-Oceananigans coupled simulation.
+\label{fig:oceananigans_coupled_example}](oceananigans_coupled_example.png)
 
-# Acknowledgements
-
-Our work is supported by the Office of Naval Research (ONR) grant
-N00014-19-1-2421. The authors thank the authors of Subzero, Georgy Manucharyan
-and Brandon Montemuro for their guidance and advice during the porting process.
-
-# References
+Finally, Subzero.jl is continuously tested against a suite of unit tests and integration tests that compare its behavior to the original MATLAB model, and confirm that the model conserves both energy and momentum.


### PR DESCRIPTION
I have made some edits to the paper, including adding some citations. The edits have included some reorganization, which makes the diff look (maybe) more significant than it really is. I'm happy to iterate on this.

After reviewing a number of papers on JOSS, I've seen that they commonly start with a short summary (acting in place of a typical abstract), followed by the statement of need, and then any number of other sections with headings chosen by the authors. 
Here I've adjusted the paper have the sections:
# Summary
# Statement of need
# Functionality

While I've continued acknowledging the original Matlab SubZero by Brandon and Georgy, I've tried to make direct comparisons less of the focus of this paper and instead highlight the utility of Subzero.jl.

Speed tests still haven't been performed, so that section remains a stub, and figure references currently included are still placeholders (and waiting to add figures before writing captions).
